### PR TITLE
Option to not turn on lights with temperature change

### DIFF
--- a/devicetypes/kriskit-trendsetter/color-temperature-light-group-device.src/color-temperature-light-group-device.groovy
+++ b/devicetypes/kriskit-trendsetter/color-temperature-light-group-device.src/color-temperature-light-group-device.groovy
@@ -101,6 +101,10 @@ metadata {
     
     main "switch"
     details(["switch", "levelLabel", "levelSliderControl", "levelValue", "levelSync", "colorTempLabel", "colorTempSliderControl", "colorTempValue", "colorTempSync", "onButton", "offButton"])
+	
+    preferences {  
+		input name: "colorChangeWithoutTurningOn", type: "bool", title: "Set Color without turning on Lights?"
+    }
 }
 
 def parse(String description) {
@@ -287,7 +291,7 @@ def setColorTemperature(val, triggerGroup) {
     if( val > 6500)
     	val = 6500
         
-    if (triggerGroup)
+    if (triggerGroup && !colorChangeWithoutTurningOn)
        on()
         
     sendEvent(name: "colorTemperature", value: val, isStateChange: true)


### PR DESCRIPTION
My color temperature lights allow you to change the temperature without turning them on. This adds an option in the device to not turn on the bulbs when changing the temperature of the group.